### PR TITLE
支持除python直接启动的判断

### DIFF
--- a/futu/__init__.py
+++ b/futu/__init__.py
@@ -57,7 +57,10 @@ def _check_module(mod_name, package_name=None, version=None, version_getter=None
 
 def _pip_get_package_version(package_name):
     import subprocess
-    proc = subprocess.Popen([sys.executable, '-m', 'pip', 'show', package_name], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if sys.executable.endswith("python"):
+        proc = subprocess.Popen([sys.executable, '-m', 'pip', 'show', package_name], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    else:
+        proc = subprocess.Popen(['pip', 'show', package_name], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     outdata, errdata = proc.communicate()
 
     eol = b'\n'


### PR DESCRIPTION
当使用`uwsgi`启动时 `sys.executable`对应的是`uwsgi`的命令，自检时会直接退出。
这时候环境中的pip就是当前环境的pip，其实在常用情况下，直接使用`pip`命令即可。