### PR TITLE
Update InitConnect.proto

### DIFF
--- a/futu/common/pb/InitConnect.proto
+++ b/futu/common/pb/InitConnect.proto
@@ -12,7 +12,7 @@ message C2S
 	optional bool recvNotify = 3; //此连接是否接收市场状态、交易需要重新解锁等等事件通知，true代表接收，FutuOpenD就会向此连接推送这些通知，反之false代表不接收不推送
 	//如果通信要加密，首先得在FutuOpenD和客户端都配置RSA密钥，不配置始终不加密
 	//如果配置了RSA密钥且指定的加密算法不为PacketEncAlgo_None则加密(即便这里不设置，配置了RSA密钥，也会采用默认加密方式)，默认采用FTAES_ECB算法
-	optional int32 packetEncAlgo = 4; //指定包加密算法，参见Common.PacketEncAlgo的枚举定义
+	optional sint32 packetEncAlgo = 4; //指定包加密算法，参见Common.PacketEncAlgo的枚举定义
 	optional int32 pushProtoFmt = 5; //指定这条连接上的推送协议格式，若不指定则使用push_proto_type配置项
 	optional string programmingLanguage = 6; //接口编程语言，用于统计语言偏好
 }


### PR DESCRIPTION
修改协议定义，将可能有负数的字段类型从int32改为sint32，这样负数会使用ZigZag编码，在不同语言中有一致的编码结果,我在使用cl-protobufs库对这个结构进行序列化时发现lisp版本和py版本不一样。